### PR TITLE
Fix the version check in order to work with sqlalchemy versions >= 1.0.0.

### DIFF
--- a/src/z3c/saconfig/utility.py
+++ b/src/z3c/saconfig/utility.py
@@ -16,8 +16,8 @@ from z3c.saconfig.interfaces import (IScopedSession, ISiteScopedSession,
                                      IEngineFactory, EngineCreatedEvent)
 
 SA_0_5_andmore = sqlalchemy.__version__ == 'svn' \
-    or (int(sqlalchemy.__version__.split('.')[:2][0]) >= 0
-        and int(sqlalchemy.__version__.split('.')[:2][1]) >= 5)
+    or (int(sqlalchemy.__version__.split('.')[:2][0]),
+        int(sqlalchemy.__version__.split('.')[:2][1]) >= (0, 5))
 
 if SA_0_5_andmore:
     SESSION_DEFAULTS = dict(


### PR DESCRIPTION
This package does not work with sqlalchemy >= 1.0.0 since the version checking is not correct. Even the tests do not pass when executed together with sqlalchemy >= 1.0.0.

Here is the fix. The tests now pass.
